### PR TITLE
Added dev sites to manifest. Added support for clicking on J drive links

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,3 +15,37 @@ chrome.runtime.onMessage.addListener(
         }
     }
 );
+
+// Find J drive links on document load
+$(document).ready(processJLinks);
+
+
+// If mac, add custom event to click handler
+function processJLinks() {
+    // Quit if not Mac
+    if (navigator.platform !== 'MacIntel') {
+        return;
+    }
+
+    var links = document.querySelectorAll(".files-table a")
+
+    for (var i = 0; i < links.length; i++) {
+        // Only bind to J drive links
+        if (links[i].href && links[i].href.substring(0, 10) === "file://j:/") {
+            links[i].addEventListener("click", handleClick);
+        }
+      }
+
+}
+
+// Handle clicking on a J drive link
+// Called only if mac and known J drive link
+function handleClick (e) {
+    // Prevent the browser from following the link
+    e.preventDefault();
+
+    // Replace link with Mac link
+    var href = e.target.href.replace("j:", "/Volumes/snfs");
+
+    chrome.runtime.sendMessage({"message": "open_new_tab", "url": href})
+}

--- a/manifest.json
+++ b/manifest.json
@@ -8,8 +8,10 @@
   "content_scripts": [
     {
       "matches": [
-        "https://internal-ghdx.healthdata.org/*",
-        "http://internal-ghdx.healthdata.org/*"
+        "*://internal-ghdx.healthdata.org/*",
+        "*://dev.ghdx.healthdata.org/*",
+        "*://stage.ghdx.healthdata.org/*",
+        "*://*.k8s.datatools.ihme.washington.edu/*"
       ],
     "js": ["jquery-3.2.1.min.js", "content.js"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
         "*://internal-ghdx.healthdata.org/*",
         "*://dev.ghdx.healthdata.org/*",
         "*://stage.ghdx.healthdata.org/*",
+        "*://internal.stage.ghdx.healthdata.org/*",
         "*://*.k8s.datatools.ihme.washington.edu/*"
       ],
     "js": ["jquery-3.2.1.min.js", "content.js"]


### PR DESCRIPTION
Added:

- Support for our dev sites
- Support for clicking directly on a J: drive link. When you click on it it will open in a new tab the same as when you click on the extension currently

Just let me know if there's any questions / concerns.